### PR TITLE
Add <meta charset="utf-8">to get rid of warning on FF

### DIFF
--- a/Extension/popup/index.html
+++ b/Extension/popup/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <meta charset="utf-8">
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
     <style>

--- a/Extension/popup/options.html
+++ b/Extension/popup/options.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <meta charset="utf-8">
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
     <style>

--- a/Extension/popup/pD.html
+++ b/Extension/popup/pD.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+       <meta charset="utf-8">
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
     <style>

--- a/Extension/popup/uL.html
+++ b/Extension/popup/uL.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
    <head>
+      <meta charset="utf-8">
       <!-- Latest compiled and minified CSS -->
       <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
       <style>

--- a/tests/auth_test.html
+++ b/tests/auth_test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
 		<title>Firebase + Google Auth Test</title>
 	</head>
 	<body>

--- a/tests/include_test.html
+++ b/tests/include_test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
 		<title>Firebase + Google Auth Test</title>
 	</head>
 	<body>

--- a/tests/ka_api_wrapper_test.html
+++ b/tests/ka_api_wrapper_test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
 		<title>KA Api Wrapper Test</title>
 	</head>
 	<body>

--- a/tests/project_wrapper_test.html
+++ b/tests/project_wrapper_test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
 		<title>Project Wrapper Test</title>
 	</head>
 	<body>

--- a/tests/sync_test.html
+++ b/tests/sync_test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
 		<title>Sync Test</title>
 		<style>
 			#syncBtn {


### PR DESCRIPTION
Add <meta charset="utf-8"> to get rid of the warning on Firefox about
the page rendering with garbled text on some browsers. Does not affect
the functioning of the application in any way and less errors and
warnings=better.
