### PR TITLE
Add Description on Contest Page and Make get_N_Entries Work

### DIFF
--- a/Backend/contest_judging_sys.js
+++ b/Backend/contest_judging_sys.js
@@ -104,10 +104,6 @@ window.Contest_Judging_System = (function() {
             var numberOfEntries = 0;
 
             Contest_Judging_System.loadContest(contestId, function(contestData) {
-                /* Loop through all of the entries, and determine the total number of entries that have been submitted. */
-                for (var i in contestData.entries) {
-                    numberOfEntries++;
-                }
 
                 /* Declare a variable to hold an array of keys for entries */
                 var entriesKeys = Object.keys(contestData.entries);
@@ -115,9 +111,10 @@ window.Contest_Judging_System = (function() {
                 /* An array to store the keys that we've already picked */
                 var pickedKeys = [ ];
 
-                for (var i = 0; i < n; i++) {
+                /* While we still need keys to return... */
+                while (pickedKeys.length < n) {
                     /* Pick a random index */
-                    var randIndex = Math.floor( (Math.random() * (numberOfEntries - 1)) );
+                    var randIndex = Math.floor( Math.random() * entriesKeys.length );
 
                     /* Get the key from the index that we picked */
                     var pickedKey = entriesKeys[randIndex];
@@ -127,9 +124,6 @@ window.Contest_Judging_System = (function() {
                         /* ...pick it. */
                         pickedEntries[pickedKey] = contestData.entries[pickedKey];
                         pickedKeys.push(pickedKey);
-                    } else {
-                        /* Go back and try again. */
-                        i--;
                     }
                 }
 

--- a/Client/contest.html
+++ b/Client/contest.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+        <meta charset="utf-8">
 		<title>Viewing Contest</title>
 		<link rel="icon" href="../Resources/favicon.ico">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">

--- a/Client/entry.html
+++ b/Client/entry.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+        <meta charset="utf-8">
 		<title>Viewing entry</title>
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
         <link rel="stylesheet" href="stylesheets/main.css">

--- a/Client/index.html
+++ b/Client/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <title>Contest Judging System</title>
         <link rel="icon" href="../Resources/favicon.ico">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">

--- a/Client/scripts/contest.js
+++ b/Client/scripts/contest.js
@@ -31,15 +31,8 @@ Contest_Judging_System.loadContest(contestId, function(contest) {
 		$("#contestName").text(contest.name);
 		$("#contestDescription").html("Description coming soon!");
 
-		$.ajax({
-			type: 'GET',
-			url: "http://www.khanacademy.org/api/labs/scratchpads/" + contest.id,
-			async: true,
-			complete: function(data) {
-				var detailsDiv = document.getElementById("contestDescription");
-				detailsDiv.innerHTML = data.responseJSON.description || "No description provided!";
-			}
-		})
+		var detailsDiv = document.getElementById("contestDescription");
+		detailsDiv.innerHTML = contest.desc;
 
 		console.log(contest.description);
 		/* Add all entries to the page */

--- a/Client/scripts/contest.js
+++ b/Client/scripts/contest.js
@@ -31,6 +31,17 @@ Contest_Judging_System.loadContest(contestId, function(contest) {
 		$("#contestName").text(contest.name);
 		$("#contestDescription").html("Description coming soon!");
 
+		$.ajax({
+			type: 'GET',
+			url: "http://www.khanacademy.org/api/labs/scratchpads/" + contest.id,
+			async: true,
+			complete: function(data) {
+				var detailsDiv = document.getElementById("contestDescription");
+				detailsDiv.innerHTML = data.responseJSON.description || "No description provided!";
+			}
+		})
+
+		console.log(contest.description);
 		/* Add all entries to the page */
 		for (var i in entries) {
 			(function() {

--- a/tests/rubric_get_test.html
+++ b/tests/rubric_get_test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+        <meta charset="utf-8">
 		<title>Rubric Getter Thingamabob</title>
 	</head>
 	<body>


### PR DESCRIPTION
I added the contest description to the viewing page using data from Firebase, added some more meta tags (new HTML docs=need meta tags), and I fixed a bug where get_N_Entries would not consider the last entry in a contest (as well as converting a for loop within it to a while loop which was better suited for the task).
