### PR TITLE
Made `entry.js` Cleaner and More Versatile

### DIFF
--- a/Client/scripts/entry.js
+++ b/Client/scripts/entry.js
@@ -288,9 +288,9 @@ function judgeEntry(scoreData) {
 
 $(".viewOnKA").on("click", function() {
 	/* Prompt the user with a message warning them about information that could potentially bias them. */
-	var promptMsg = prompt("By visiting the following page, you're exposing yourself to information that could bias your judging. If you agree to not let information you see on Khan Academy bias your judging, please type \"I agree\", otherwise, close this prompt.");
+	var promptMsg = prompt("By visiting the following page, you're exposing yourself to information that could bias your judging. If you agree to not let information you see on Khan Academy bias your judging, please type \"I agree\" in the box below to show that you read this message. Otherwise, close this prompt.");
 	/* If the user types 'I agree' in the prompt, open the entry on Khan Academy. */
-	if (promptMsg == "I agree") {
+	if (promptMsg != null && promptMsg.toLowerCase().indexOf("i agree") > -1) {
 		window.open("https://www.khanacademy.org/computer-programming/entry/" + entryId);
 	}
 });

--- a/Client/scripts/entry.js
+++ b/Client/scripts/entry.js
@@ -162,8 +162,8 @@ function loadEntry() {
                     var curSlider = document.createElement("div");
                     curSlider.className = "judgingSlider";
                     curSlider.role = "slider";
-                    /* This is put in a function wrapper to save the value of curLabel, scoreData, and k for the function inside the JSON object. */
-                    (function(curLabel, scoreData, k) {
+                    /* This is put in a function wrapper to save the value of curLabel, scoreData, rubricName, and k for the function inside the JSON object. */
+                    (function(curLabel, scoreData, rubricName, k) {
                         /* Use jQuery UI to create slider */
                         $(curSlider).slider({
                             range: "max",
@@ -177,7 +177,7 @@ function loadEntry() {
                                 scoreData[k] = ui.value;
                             }
                         });
-                    })(curLabel, scoreData, k);
+                    })(curLabel, scoreData, rubricName, k);
 
                     /* Append everything to whatever it needs to be appended to */
                     curGroup.appendChild(curLabel);


### PR DESCRIPTION
Basically, I made `entry.js` so that instead of using the ad hoc properties of `Level`, `Clean_Code`, etc., I took the properties from `rubrics` in the `Contest_Judging_System.getRubrics()` callback and used it to make buttons and sliders for each property. For properties `k` such that `rubrics[k].hasOwnProperty("keys")` holds (i.e. `k="Level"`), buttons are made and for all other properties, sliders are made.

Also, if you want the buttons and sliders to be in a specific order like it was before (right now, it's kind of in a weird order because I just loop through `rubrics` with `for (k in rubrics)`), you should specify the order in `rubrics` so we're not being ad hoc.
