### PR TITLE
More Descriptive Webpage Titles

### DIFF
--- a/contest.html
+++ b/contest.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="Khan Academy Contest Judging System 2.0">
+        <meta property="og:title" content="Contest - Khan Academy Contest Judging System 2.0">
         <meta property="og:site_name" content="Khan Academy Contest Judging System">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>Khan Academy Contest Judging System</title>
+        <title>Contest - Khan Academy Contest Judging System</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">

--- a/contest.html
+++ b/contest.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="The Officially Unofficial Khan Academy Contest Judging System 2.0">
+        <meta property="og:title" content="Khan Academy Contest Judging System 2.0">
         <meta property="og:site_name" content="Khan Academy Contest Judging System">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>The Officially Unofficial Khan Academy Contest Judging System</title>
+        <title>Khan Academy Contest Judging System</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">
@@ -20,7 +20,7 @@
         <div class="navbar-fixed">
             <nav class="amber">
                 <div class="nav-wrapper">
-                    <a href="index.html" class="brand-logo center">Contest Judging System</a>
+                    <a href="index.html" class="brand-logo center">Khan Academy Contest Judging System</a>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li><a href="index.html">Home</a></li>
                         <li><a id="authBtn" href="#">&nbsp;</a></li>

--- a/contest.html
+++ b/contest.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="Contest - Khan Academy Contest Judging System 2.0">
-        <meta property="og:site_name" content="Khan Academy Contest Judging System">
+        <meta property="og:title" content="Contest - Contest Judging System for Khan Academy 2.0">
+        <meta property="og:site_name" content="Contest Judging System for Khan Academy">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>Contest - Khan Academy Contest Judging System</title>
+        <title>Contest - Contest Judging System for Khan Academy</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">
@@ -20,7 +20,7 @@
         <div class="navbar-fixed">
             <nav class="amber">
                 <div class="nav-wrapper">
-                    <a href="index.html" class="brand-logo center">Khan Academy Contest Judging System</a>
+                    <a href="index.html" class="brand-logo center">Contest Judging System for Khan Academy</a>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li><a href="index.html">Home</a></li>
                         <li><a id="authBtn" href="#">&nbsp;</a></li>

--- a/entry.html
+++ b/entry.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="Contest Entry - Khan Academy Contest Judging System 2.0">
-        <meta property="og:site_name" content="Khan Academy Contest Judging System">
+        <meta property="og:title" content="Contest Entry - Contest Judging System for Khan Academy 2.0">
+        <meta property="og:site_name" content="Contest Judging System for Khan Academy">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>Contest Entry - Khan Academy Contest Judging System</title>
+        <title>Contest Entry - Contest Judging System for Khan Academy</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">
@@ -20,7 +20,7 @@
         <div class="navbar-fixed">
             <nav class="amber">
                 <div class="nav-wrapper">
-                    <a href="index.html" class="brand-logo center">Khan Academy Contest Judging System</a>
+                    <a href="index.html" class="brand-logo center">Contest Judging System for Khan Academy</a>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li><a href="index.html">Home</a></li>
                         <li><a id="authBtn" href="#">&nbsp;</a></li>

--- a/entry.html
+++ b/entry.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="The Officially Unofficial Khan Academy Contest Judging System 2.0">
+        <meta property="og:title" content="Khan Academy Contest Judging System 2.0">
         <meta property="og:site_name" content="Khan Academy Contest Judging System">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>The Officially Unofficial Khan Academy Contest Judging System</title>
+        <title>Khan Academy Contest Judging System</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">
@@ -20,7 +20,7 @@
         <div class="navbar-fixed">
             <nav class="amber">
                 <div class="nav-wrapper">
-                    <a href="index.html" class="brand-logo center">Contest Judging System</a>
+                    <a href="index.html" class="brand-logo center">Khan Academy Contest Judging System</a>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li><a href="index.html">Home</a></li>
                         <li><a id="authBtn" href="#">&nbsp;</a></li>

--- a/entry.html
+++ b/entry.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="Khan Academy Contest Judging System 2.0">
+        <meta property="og:title" content="Contest Entry - Khan Academy Contest Judging System 2.0">
         <meta property="og:site_name" content="Khan Academy Contest Judging System">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>Khan Academy Contest Judging System</title>
+        <title>Contest Entry - Khan Academy Contest Judging System</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="Khan Academy Contest Judging System 2.0">
-        <meta property="og:site_name" content="Khan Academy Contest Judging System">
+        <meta property="og:title" content="Contest Judging System for Khan Academy 2.0">
+        <meta property="og:site_name" content="Contest Judging System for Khan Academy">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>Khan Academy Contest Judging System</title>
+        <title>Contest Judging System for Khan Academy</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">
@@ -20,7 +20,7 @@
         <div class="navbar-fixed">
             <nav class="amber">
                 <div class="nav-wrapper">
-                    <a href="#!" class="brand-logo center">Khan Academy Contest Judging System</a>
+                    <a href="#!" class="brand-logo center">Contest Judging System for Khan Academy</a>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li class="active"><a href="index.html">Home</a></li>
                         <li><a id="authBtn" href="#">&nbsp;</a></li>

--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="The Officially Unofficial Khan Academy Contest Judging System 2.0">
+        <meta property="og:title" content="Khan Academy Contest Judging System 2.0">
         <meta property="og:site_name" content="Khan Academy Contest Judging System">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>The Officially Unofficial Khan Academy Contest Judging System</title>
+        <title>Khan Academy Contest Judging System</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">
@@ -20,7 +20,7 @@
         <div class="navbar-fixed">
             <nav class="amber">
                 <div class="nav-wrapper">
-                    <a href="#!" class="brand-logo center">Contest Judging System</a>
+                    <a href="#!" class="brand-logo center">Khan Academy Contest Judging System</a>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li class="active"><a href="index.html">Home</a></li>
                         <li><a id="authBtn" href="#">&nbsp;</a></li>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="Contest Leaderboard - Khan Academy Contest Judging System 2.0">
-        <meta property="og:site_name" content="Khan Academy Contest Judging System">
+        <meta property="og:title" content="Contest Leaderboard - Contest Judging System for Khan Academy 2.0">
+        <meta property="og:site_name" content="Contest Judging System for Khan Academy">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>Contest Leaderboard - Khan Academy Contest Judging System</title>
+        <title>Contest Leaderboard - Contest Judging System for Khan Academy</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">
@@ -21,7 +21,7 @@
         <div class="navbar-fixed">
             <nav class="amber">
                 <div class="nav-wrapper">
-                    <a href="#!" class="brand-logo center">Khan Academy Contest Judging System</a>
+                    <a href="#!" class="brand-logo center">Contest Judging System for Khan Academy</a>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li><a href="index.html">Home</a></li>
                         <li><a id="authBtn" href="#">&nbsp;</a></li>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="Leaderboard - Khan Academy Contest Judging System 2.0">
+        <meta property="og:title" content="Contest Leaderboard - Khan Academy Contest Judging System 2.0">
         <meta property="og:site_name" content="Khan Academy Contest Judging System">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>Leaderboard - Khan Academy Contest Judging System</title>
+        <title>Contest Leaderboard - Khan Academy Contest Judging System</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -2,13 +2,13 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta property="og:title" content="The Officially Unofficial Khan Academy Contest Judging System 2.0">
+        <meta property="og:title" content="Leaderboard - Khan Academy Contest Judging System 2.0">
         <meta property="og:site_name" content="Khan Academy Contest Judging System">
         <meta property="og:type" content="website">
         <meta property="og:url" content="http://gigabytegiant.com/kacjs">
         <meta property="og:description" content="Browse and judge Khan Academy contests, from one, easy-to-use, site!">
 
-        <title>The Officially Unofficial Khan Academy Contest Judging System</title>
+        <title>Leaderboard - Khan Academy Contest Judging System</title>
 
         <link rel="shortcut icon" type="image/x-icon" href="./build/resources/favicon.ico">
         <link href="./build/css/material_icons.css" rel="stylesheet">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -21,7 +21,7 @@
         <div class="navbar-fixed">
             <nav class="amber">
                 <div class="nav-wrapper">
-                    <a href="#!" class="brand-logo center">Contest Judging System</a>
+                    <a href="#!" class="brand-logo center">Khan Academy Contest Judging System</a>
                     <ul id="nav-mobile" class="right hide-on-med-and-down">
                         <li><a href="index.html">Home</a></li>
                         <li><a id="authBtn" href="#">&nbsp;</a></li>


### PR DESCRIPTION
- Got rid of "The Officially Unofficial" in all the page titles.
- Added more descriptive titles based on the current page (e.g. "Contest Entry - Khan Academy Contest Judging System").
- Changed the nav title to say "Khan Academy Contest Judging System" across the board.

EDIT:
- Changed the page titles from "The Officially Unofficial Khan Academy Contest Judging System" to "Contest Judging System for Khan Academy".
